### PR TITLE
feat: Provisioned application DynamoDB table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,4 @@ __marimo__/
 .terraform.tfstate.lock.info
 terraform.tfstate
 terraform.tfstate.backup
+backend.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,9 @@ repos:
       - id: checkov
         verbose: true
         entry: pipenv run checkov -f ./infra/local/main.tf
+      - id: checkov
+        verbose: true
+        entry: pipenv run checkov -f ./infra/aws/main.tf
   - repo: local
     hooks:
       - id: terraform-fmt

--- a/infra/aws/backend.tf
+++ b/infra/aws/backend.tf
@@ -1,0 +1,6 @@
+# The S3 bucket containing state has the AWS account number in the file
+# To prevent committing this to git, define the backend config in a
+# backend.hcl file and add that file to .gitignore
+terraform {
+  backend "s3" {}
+}

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+resource "aws_dynamodb_table" "application_table" {
+  # checkov:skip=CKV_AWS_119:Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK
+  name         = "fantasy-analytics-app-db"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "metricId"
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "metricId"
+    type = "S"
+  }
+
+  tags = {
+    Project     = "fantasy-analytics-app"
+    Environment = "PROD"
+  }
+}


### PR DESCRIPTION
## This PR does the following:
- [x] Deploy infrastructure
- [ ] Create/update code
    - [ ] Frontend
    - [ ] Backend
    - [ ] Data fetch scripts
- [ ] Fix code vulnerabilities
- [x] Miscellaneous (update templates, config files)

## PR Description
- Creates a DynamoDB table for the application with partition key `metricId` (this is the initial provision so this table is subject to change)
- Updated the pre-commit Checkov hook to check `main.tf` files in both directories under the infra folder
- Created a backend configuration for `infra/aws` and stored the configuration in `backend.hcl` which was added to the .gitignore

## PR Checklist
- [x] Reviewed by GitHub Copilot
- [x] Passes pre-commit configuration
- [x] PR description contains list of all changes