### PR TITLE
fix: address Dependabot vulnerabilities

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,5 +7,7 @@ name = "pypi"
 python_version = "3.12"
 
 [dev-packages]
+asteval = ">=1.0.6"
 checkov = "*"
 pre-commit = "*"
+urllib3 = ">=2.5.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f8939efb68d7fd7c4e94d724889d983f3a0b91163aaff1a63dc7e722f602ff8d"
+            "sha256": "f7ec5f9b74e6b70e2d2caab13d6140e8cf38e503e15624ab4a3e087738e546da"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -159,11 +159,12 @@
         },
         "asteval": {
             "hashes": [
-                "sha256:082b95312578affc8a6d982f7d92b7ac5de05634985c87e7eedd3188d31149fa",
-                "sha256:bac3c8dd6d2b789e959cfec9bb296fb8338eec066feae618c462132701fbc665"
+                "sha256:1aa8e7304b2e171a90d64dd269b648cacac4e46fe5de54ac0db24776c0c4a19f",
+                "sha256:5e119ed306e39199fd99c881cea0e306b3f3807f050c9be79829fe274c6378dc"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.0.5"
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.0.6"
         },
         "attrs": {
             "hashes": [
@@ -175,11 +176,11 @@
         },
         "bc-detect-secrets": {
             "hashes": [
-                "sha256:0ab63d6c4f6680ec2dbe42cc3c63480568c55dbb6254afcc5bb6d4375a4e1d27",
-                "sha256:bebd82c56055c600335f85db95f7ca3b434087f16292a0396a60705de1b94183"
+                "sha256:4bd08292a975bfc9b95771e118dd1131e1afbd479610eb29e4e0c15bd33677fc",
+                "sha256:629df912f2a4f4d5039cc1fece906c34700586f7db1ae6a8d1c830c25df6db9b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.5.44"
+            "version": "==1.5.41"
         },
         "bc-jsonpath-ng": {
             "hashes": [
@@ -191,11 +192,11 @@
         },
         "bc-python-hcl2": {
             "hashes": [
-                "sha256:b0cce4cea16823f7da7fefa0f8177dfb91f51a1befe64ef59d8fe4d5ac616eec",
-                "sha256:fae62b2a41a675ad330d134d82576526db755f72bbd0e5a850de3d85fc24c40e"
+                "sha256:90d2afbaa2c7e77b7b30bf58180084e11d95287f7c3e19c5bfbdb54ab2fd80e9",
+                "sha256:ac8ff59fb9bd437ea29b89a7d7c507fd0a1e957845bae9aeac69f2892b8d681e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.4.3"
+            "version": "==0.4.2"
         },
         "beartype": {
             "hashes": [
@@ -207,11 +208,11 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b",
-                "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"
+                "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695",
+                "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==4.13.4"
+            "version": "==4.13.5"
         },
         "boolean.py": {
             "hashes": [
@@ -428,12 +429,12 @@
         },
         "checkov": {
             "hashes": [
-                "sha256:223d2247ccd518bb904619ba9cabb15412be3aafccf55324bc34ba5f804563ba",
-                "sha256:c79274971dd403fd6870714d48f055ffd66f8ed2af66b9214d4eb396e4a64fc9"
+                "sha256:e70cc3fccfad99125c96045250b6f35a839c08104a55498a427b4e8891c29962",
+                "sha256:f7b1bd8533c4c17db2471baed9e3ce97cc22a248ababd7516ea3e907123976ad"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.2.464"
+            "version": "==3.2.414"
         },
         "click": {
             "hashes": [
@@ -1037,6 +1038,14 @@
             ],
             "markers": "python_version >= '3.11'",
             "version": "==2.3.2"
+        },
+        "openai": {
+            "hashes": [
+                "sha256:4be1dad329a65b4ce1a660fe6d5431b438f429b5855c883435f0f7fcb6d2dcc8",
+                "sha256:d18690f9e3d31eedb66b57b88c2165d760b24ea0a01f150dd3f068155088ce68"
+            ],
+            "markers": "python_full_version >= '3.7.1'",
+            "version": "==0.28.1"
         },
         "orjson": {
             "hashes": [
@@ -2011,11 +2020,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
-                "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"
+                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.20"
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.5.0"
         },
         "virtualenv": {
             "hashes": [


### PR DESCRIPTION
## This PR does the following:
- [ ] Deploy infrastructure
- [ ] Create/update code
    - [ ] Frontend
    - [ ] Backend
    - [ ] Data fetch scripts
- [x] Fix code vulnerabilities
- [ ] Miscellaneous (update templates, config files)

## PR Description
- Addresses Dependabot alerts [#1](https://github.com/amolrairikar/espn-fantasy-league-analytics/security/dependabot/1) and [#2](https://github.com/amolrairikar/espn-fantasy-league-analytics/security/dependabot/2) by pinning asteval to at least v1.0.6
- Addresses Dependabot alert [#3](https://github.com/amolrairikar/espn-fantasy-league-analytics/security/dependabot/3) by pinning urllib3 to at least v2.5.0

## PR Checklist
- [x] Reviewed by GitHub Copilot
- [x] Passes pre-commit configuration
- [x] PR description contains list of all changes